### PR TITLE
Fix not finding services

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bloomrpc-mock",
   "description": "Automock your grpc services",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "author": "Fabrizio Fenoglio (UtilityWarehouse)",
   "bin": {
     "brpc-mock": "./bin/run",

--- a/src/protobuf.ts
+++ b/src/protobuf.ts
@@ -116,29 +116,13 @@ export function walkServices(proto: Proto, onService: (service: Service, def: an
     });
 }
 
-export function matchingAncestorNamespaceLookup(typeName: string, parentNamespace: Namespace, namespaceChain: string): string {
-  if (!parentNamespace.parent) {
-    // Root namespace
-    const namespaceElements = namespaceChain.split('.');
-    const firstOccurrence = namespaceElements.indexOf(typeName);
-    const lastOccurrence = namespaceElements.lastIndexOf(typeName);
-    return namespaceElements.slice(firstOccurrence, lastOccurrence + 1).join('.');
-  }
-
-  namespaceChain = parentNamespace.name + '.' + namespaceChain;
-
-  return matchingAncestorNamespaceLookup(typeName, parentNamespace.parent, namespaceChain);
-}
-
 export function walkNamespace(root: Root, onNamespace: (namespace: Namespace) => void, parentNamespace?: Namespace) {
-  const nestedType = parentNamespace ? parentNamespace.nested : root.nested;
+  const namespace = parentNamespace ? parentNamespace : root;
+  const nestedType = namespace.nested;
 
   if (nestedType) {
     Object.keys(nestedType).forEach((typeName: string) => {
-      if (parentNamespace) {
-        typeName = matchingAncestorNamespaceLookup(typeName, parentNamespace, typeName);
-      }
-      const nestedNamespace = root.lookup(typeName);
+      const nestedNamespace = root.lookup(`${namespace.fullName}.${typeName}`);
       if (nestedNamespace && isNamespace(nestedNamespace)) {
         onNamespace(nestedNamespace as Namespace);
         walkNamespace(root, onNamespace, nestedNamespace as Namespace);


### PR DESCRIPTION
Fix [not finding services when dealing with the same proto names in the different folders](https://github.com/uw-labs/bloomrpc/issues/309)

## Steps to reproduce 
1. Clone `https://github.com/vavsab/bloom-rpc-issues/`
2. `cd Issue2`
3. Run bloomrpc-mock for `merge.proto`. For local environment it's smth similar to `./bin/run /mnt/c/Projects/Mapped/bloomRPC/Issue2/org/api/merge/merge.proto --include=/mnt/c/Projects/Mapped/bloomRPC/Issue2/`
4. See that no services were found
![image](https://user-images.githubusercontent.com/10233442/116865038-8d4d3180-ac11-11eb-86d2-88370bfc80c9.png)

If you do it through BloomRRC UI you will get empty proto
![image](https://user-images.githubusercontent.com/10233442/116865208-ddc48f00-ac11-11eb-93ab-a14d0391931d.png)

## Notes
As soon as I comment [this line](https://github.com/vavsab/bloom-rpc-issues/blob/main/Issue2/org/api/merge/merge.proto#L6) the service becomes visible.

**bloomrpc-mock** npm version: **0.3.2**