### PR TITLE
Fix Bytes mock

### DIFF
--- a/src/automock.ts
+++ b/src/automock.ts
@@ -261,7 +261,13 @@ function mockScalar(type: string, fieldName: string): any {
   case 'float':
     return 1.1;
   case 'bytes':
-    return new Buffer('Hello');
+    let bytes = [];
+    const str = 'Hello';
+    let buffer = new Buffer(str, 'utf16le');
+    for (let b of buffer) {
+      bytes.push(b);
+    }
+    return bytes;
   default:
     return null;
   }


### PR DESCRIPTION
**Context:**

I incurred in [this same issue](https://github.com/uw-labs/bloomrpc/issues/101) and it seems like passing raw bytes instead of a full buffer spec works as expected.

I dug into `bloomrpc`'s code and found out that the mock generation is done in this repository; so I'm opening this tiny PR to fix it.

If this is ok and gets merged, I can then open a PR in `bloomrpc` to upgrade `bloomrpc-mock`'s dependency and fix the issue.

**What changes:**

Given the following test proto:

```
syntax = "proto3";

package testproto;

service TestService {
  rpc Test(TestRequest) returns (TestResponse);
}

message TestRequest {
  string message = 1;
  bytes body = 2;
}

message TestResponse {}
```

The generated mock leads to:

```
{
  "message": "Hello",
  "body": {
    "type": "Buffer",
    "data": [
      72,
      101,
      108,
      108,
      111
    ]
  }
}
```

Which can't be deserialised correctly by the GRPC server.

The proposed fix leads to the following mock generation:

```
{
  "message": "Hello",
  "body": [
    72,
    0,
    101,
    0,
    108,
    0,
    108,
    0,
    111,
    0
  ]
}
```

Which works as expected.